### PR TITLE
chore: update flux source v1beta2 to v1 (#1602)

### DIFF
--- a/api/v1beta1/clusterdeployment_types.go
+++ b/api/v1beta1/clusterdeployment_types.go
@@ -97,6 +97,11 @@ type ClusterDeploymentStatus struct {
 	// Currently compatible exact Kubernetes version of the cluster. Being set only if
 	// provided by the corresponding ClusterTemplate.
 	KubernetesVersion string `json:"k8sVersion,omitempty"`
+	// +patchMergeKey=type
+	// +patchStrategy=merge
+	// +listType=map
+	// +listMapKey=type
+
 	// Conditions contains details for the current state of the ClusterDeployment.
 	Conditions []metav1.Condition `json:"conditions,omitempty"`
 

--- a/api/v1beta1/common.go
+++ b/api/v1beta1/common.go
@@ -34,6 +34,9 @@ const (
 
 	// DeletingCondition indicates a resource is deleting.
 	DeletingCondition string = "Deleting"
+
+	// PredeclaredSecretsExistCondition indicates whether all object's required (and predeclared) Secrets exist.
+	PredeclaredSecretsExistCondition = "PredeclaredSecretsExist"
 )
 
 type (

--- a/api/v1beta1/credential_types.go
+++ b/api/v1beta1/credential_types.go
@@ -36,6 +36,11 @@ type CredentialSpec struct {
 
 // CredentialStatus defines the observed state of Credential
 type CredentialStatus struct {
+	// +patchMergeKey=type
+	// +patchStrategy=merge
+	// +listType=map
+	// +listMapKey=type
+
 	// Conditions contains details for the current state of the Credential.
 	Conditions []metav1.Condition `json:"conditions,omitempty"`
 	// +kubebuilder:default:=false

--- a/api/v1beta1/management_types.go
+++ b/api/v1beta1/management_types.go
@@ -127,9 +127,10 @@ type ManagementStatus struct {
 	CAPIContracts map[string]CompatibilityContracts `json:"capiContracts,omitempty"`
 	// Components indicates the status of installed KCM components and CAPI providers.
 	Components map[string]ComponentStatus `json:"components,omitempty"`
+	// +patchMergeKey=type
+	// +patchStrategy=merge
 	// +listType=map
 	// +listMapKey=type
-	// +kubebuilder:validation:MaxItems=32
 
 	// Conditions represents the observations of a Management's current state.
 	Conditions []metav1.Condition `json:"conditions,omitempty"`
@@ -155,6 +156,10 @@ type ComponentStatus struct {
 	ExposedProviders Providers `json:"exposedProviders,omitempty"`
 	// Success represents if a component installation was successful
 	Success bool `json:"success,omitempty"`
+}
+
+func (in *Management) GetConditions() *[]metav1.Condition {
+	return &in.Status.Conditions
 }
 
 // +kubebuilder:object:root=true

--- a/api/v1beta1/multiclusterservice_types.go
+++ b/api/v1beta1/multiclusterservice_types.go
@@ -162,6 +162,11 @@ type ServiceStatus struct {
 	ClusterName string `json:"clusterName"`
 	// ClusterNamespace is the namespace of the associated cluster.
 	ClusterNamespace string `json:"clusterNamespace,omitempty"`
+	// +patchMergeKey=type
+	// +patchStrategy=merge
+	// +listType=map
+	// +listMapKey=type
+
 	// Conditions contains details for the current state of managed services.
 	Conditions []metav1.Condition `json:"conditions,omitempty"`
 }
@@ -172,6 +177,11 @@ type MultiClusterServiceStatus struct {
 	Services []ServiceStatus `json:"services,omitempty"`
 	// ServicesUpgradePaths contains details for the state of services upgrade paths.
 	ServicesUpgradePaths []ServiceUpgradePaths `json:"servicesUpgradePaths,omitempty"`
+	// +patchMergeKey=type
+	// +patchStrategy=merge
+	// +listType=map
+	// +listMapKey=type
+
 	// Conditions contains details for the current state of the MultiClusterService.
 	Conditions []metav1.Condition `json:"conditions,omitempty"`
 	// ObservedGeneration is the last observed generation.

--- a/api/v1beta1/release_types.go
+++ b/api/v1beta1/release_types.go
@@ -78,12 +78,21 @@ func (in *Release) Templates() []string {
 
 // ReleaseStatus defines the observed state of Release
 type ReleaseStatus struct {
+	// +patchMergeKey=type
+	// +patchStrategy=merge
+	// +listType=map
+	// +listMapKey=type
+
 	// Conditions contains details for the current state of the Release
 	Conditions []metav1.Condition `json:"conditions,omitempty"`
 	// ObservedGeneration is the last observed generation.
 	ObservedGeneration int64 `json:"observedGeneration,omitempty"`
 	// Ready indicates whether KCM is ready to be upgraded to this Release.
 	Ready bool `json:"ready,omitempty"`
+}
+
+func (in *Release) GetConditions() *[]metav1.Condition {
+	return &in.Status.Conditions
 }
 
 // +kubebuilder:object:root=true

--- a/api/v1beta1/servicetemplate_types.go
+++ b/api/v1beta1/servicetemplate_types.go
@@ -154,6 +154,10 @@ type SourceStatus struct {
 
 	// Artifact is the artifact that was generated from the template source.
 	Artifact *sourcev1.Artifact `json:"artifact,omitempty"`
+	// +patchMergeKey=type
+	// +patchStrategy=merge
+	// +listType=map
+	// +listMapKey=type
 
 	// Conditions reflects the conditions of the remote source object.
 	Conditions []metav1.Condition `json:"conditions,omitempty"`

--- a/api/v1beta1/servicetemplate_types.go
+++ b/api/v1beta1/servicetemplate_types.go
@@ -20,7 +20,6 @@ import (
 	"github.com/Masterminds/semver/v3"
 	helmcontrollerv2 "github.com/fluxcd/helm-controller/api/v2"
 	sourcev1 "github.com/fluxcd/source-controller/api/v1"
-	sourcev1beta2 "github.com/fluxcd/source-controller/api/v1beta2"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -94,7 +93,7 @@ type LocalSourceRef struct {
 
 	// Namespace is the namespace of the local source. Cross-namespace references
 	// are only allowed when the Kind is one of [github.com/fluxcd/source-controller/api/v1.GitRepository],
-	// [github.com/fluxcd/source-controller/api/v1.Bucket] or [github.com/fluxcd/source-controller/api/v1beta2.OCIRepository].
+	// [github.com/fluxcd/source-controller/api/v1.Bucket] or [github.com/fluxcd/source-controller/api/v1.OCIRepository].
 	// If the Kind is ConfigMap or Secret, the namespace will be ignored.
 	Namespace string `json:"namespace,omitempty"`
 }
@@ -126,9 +125,9 @@ type EmbeddedBucketSpec struct {
 	sourcev1.BucketSpec `json:",inline"`
 }
 
-// EmbeddedOCIRepositorySpec is the embedded [github.com/fluxcd/source-controller/api/v1beta2.OCIRepositorySpec].
+// EmbeddedOCIRepositorySpec is the embedded [github.com/fluxcd/source-controller/api/v1.OCIRepositorySpec].
 type EmbeddedOCIRepositorySpec struct {
-	sourcev1beta2.OCIRepositorySpec `json:",inline"`
+	sourcev1.OCIRepositorySpec `json:",inline"`
 }
 
 // ServiceTemplateStatus defines the observed state of ServiceTemplate
@@ -315,10 +314,10 @@ func (t *ServiceTemplate) LocalSourceObject() (client.Object, string) {
 		return &sourcev1.Bucket{
 			ObjectMeta: localSourceMeta,
 		}, sourcev1.BucketKind
-	case sourcev1beta2.OCIRepositoryKind:
-		return &sourcev1beta2.OCIRepository{
+	case sourcev1.OCIRepositoryKind:
+		return &sourcev1.OCIRepository{
 			ObjectMeta: localSourceMeta,
-		}, sourcev1beta2.OCIRepositoryKind
+		}, sourcev1.OCIRepositoryKind
 	default:
 		return nil, ""
 	}
@@ -352,10 +351,10 @@ func (t *ServiceTemplate) RemoteSourceObject() (client.Object, string) {
 			Spec:       remoteSourceSpec.Bucket.BucketSpec,
 		}, sourcev1.BucketKind
 	case remoteSourceSpec.OCI != nil:
-		return &sourcev1beta2.OCIRepository{
+		return &sourcev1.OCIRepository{
 			ObjectMeta: fluxSourceMeta,
 			Spec:       remoteSourceSpec.OCI.OCIRepositorySpec,
-		}, sourcev1beta2.OCIRepositoryKind
+		}, sourcev1.OCIRepositoryKind
 	default:
 		return nil, ""
 	}

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -89,29 +89,30 @@ func init() {
 
 func main() {
 	var (
-		metricsAddr                string
-		probeAddr                  string
-		secureMetrics              bool
-		enableHTTP2                bool
-		templatesRepoURL           string
-		globalRegistry             string
-		globalK0sURL               string
-		insecureRegistry           bool
-		registryCredentialsSecret  string
-		registryCertSecret         string
-		createManagement           bool
-		createAccessManagement     bool
-		createRelease              bool
-		createTemplates            bool
-		validateClusterUpgradePath bool
-		kcmTemplatesChartName      string
-		enableTelemetry            bool
-		enableWebhook              bool
-		webhookPort                int
-		webhookCertDir             string
-		pprofBindAddress           string
-		leaderElectionNamespace    string
-		enableSveltosCtrl          bool
+		metricsAddr                   string
+		probeAddr                     string
+		secureMetrics                 bool
+		enableHTTP2                   bool
+		templatesRepoURL              string
+		globalRegistry                string
+		globalK0sURL                  string
+		insecureRegistry              bool
+		registryCredentialsSecretName string
+		registryCertSecretName        string
+		k0sURLCertSecretName          string
+		createManagement              bool
+		createAccessManagement        bool
+		createRelease                 bool
+		createTemplates               bool
+		validateClusterUpgradePath    bool
+		kcmTemplatesChartName         string
+		enableTelemetry               bool
+		enableWebhook                 bool
+		webhookPort                   int
+		webhookCertDir                string
+		pprofBindAddress              string
+		leaderElectionNamespace       string
+		enableSveltosCtrl             bool
 	)
 
 	flag.StringVar(&metricsAddr, "metrics-bind-address", ":8080", "The address the metric endpoint binds to.")
@@ -127,10 +128,11 @@ func main() {
 		"Global registry which will be passed as global.registry value for all providers and ClusterDeployments")
 	flag.StringVar(&globalK0sURL, "global-k0s-url", "",
 		"K0s URL prefix which will be passed directly as global.k0sURL to all ClusterDeployments configs")
-	flag.StringVar(&registryCredentialsSecret, "registry-creds-secret", "",
-		"Secret containing authentication credentials for the registry.")
-	flag.StringVar(&registryCertSecret, "registry-cert-secret", "",
-		"Secret containing a client certificate (`tls.crt`) and private key (`tls.key`) and/or a CA certificate (`ca.crt`).")
+	flag.StringVar(&registryCredentialsSecretName, "registry-creds-secret", "",
+		"Name of a Secret containing authentication credentials for the registry.")
+	flag.StringVar(&registryCertSecretName, "registry-cert-secret-name", "",
+		"Name of a Secret containing a client certificate (`tls.crt`) and private key (`tls.key`) and/or a CA certificate (`ca.crt`) for the registry endpoint")
+	flag.StringVar(&k0sURLCertSecretName, "k0s-url-cert-secret-name", "", "Name of a Secret containing a client certificate (`tls.crt`) and private key (`tls.key`) and (optionally) a CA certificate (`ca.crt`) for the k0s download URL")
 	flag.BoolVar(&insecureRegistry, "insecure-registry", false, "Allow connecting to an HTTP registry.")
 	flag.BoolVar(&createManagement, "create-management", true, "Create a Management object with default configuration upon initial installation.")
 	flag.BoolVar(&createAccessManagement, "create-access-management", true,
@@ -251,11 +253,11 @@ func main() {
 		CreateManagement: createManagement,
 		SystemNamespace:  currentNamespace,
 		DefaultRegistryConfig: helm.DefaultRegistryConfig{
-			URL:               templatesRepoURL,
-			RepoType:          determinedRepositoryType,
-			CredentialsSecret: registryCredentialsSecret,
-			CertSecret:        registryCertSecret,
-			Insecure:          insecureRegistry,
+			URL:                   templatesRepoURL,
+			RepoType:              determinedRepositoryType,
+			CredentialsSecretName: registryCredentialsSecretName,
+			CertSecretName:        registryCertSecretName,
+			Insecure:              insecureRegistry,
 		},
 	}
 
@@ -283,7 +285,8 @@ func main() {
 		IsDisabledValidationWH: !enableWebhook,
 		GlobalRegistry:         globalRegistry,
 		GlobalK0sURL:           globalK0sURL,
-		RegistryCertSecret:     registryCertSecret,
+		K0sURLCertSecretName:   k0sURLCertSecretName,
+		RegistryCertSecretName: registryCertSecretName,
 	}).SetupWithManager(mgr); err != nil {
 		setupLog.Error(err, "unable to create controller", "controller", "Management")
 		os.Exit(1)
@@ -322,11 +325,11 @@ func main() {
 		KCMTemplatesChartName: kcmTemplatesChartName,
 		SystemNamespace:       currentNamespace,
 		DefaultRegistryConfig: helm.DefaultRegistryConfig{
-			URL:               templatesRepoURL,
-			RepoType:          determinedRepositoryType,
-			CredentialsSecret: registryCredentialsSecret,
-			CertSecret:        registryCertSecret,
-			Insecure:          insecureRegistry,
+			URL:                   templatesRepoURL,
+			RepoType:              determinedRepositoryType,
+			CredentialsSecretName: registryCredentialsSecretName,
+			CertSecretName:        registryCertSecretName,
+			Insecure:              insecureRegistry,
 		},
 	}).SetupWithManager(mgr); err != nil {
 		setupLog.Error(err, "unable to create controller", "controller", "Release")

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -23,7 +23,6 @@ import (
 
 	hcv2 "github.com/fluxcd/helm-controller/api/v2"
 	sourcev1 "github.com/fluxcd/source-controller/api/v1"
-	sourcev1beta2 "github.com/fluxcd/source-controller/api/v1beta2"
 	sveltosv1beta1 "github.com/projectsveltos/addon-controller/api/v1beta1"
 	libsveltosv1beta1 "github.com/projectsveltos/libsveltos/api/v1beta1"
 	infobloxv1alpha1 "github.com/telekom/cluster-api-ipam-provider-infoblox/api/v1alpha1"
@@ -77,7 +76,6 @@ func init() {
 
 	utilruntime.Must(kcmv1.AddToScheme(scheme))
 	utilruntime.Must(sourcev1.AddToScheme(scheme))
-	utilruntime.Must(sourcev1beta2.AddToScheme(scheme))
 	utilruntime.Must(hcv2.AddToScheme(scheme))
 	utilruntime.Must(sveltosv1beta1.AddToScheme(scheme))
 	utilruntime.Must(libsveltosv1beta1.AddToScheme(scheme))

--- a/internal/controller/ipam/suite_test.go
+++ b/internal/controller/ipam/suite_test.go
@@ -24,7 +24,6 @@ import (
 
 	helmcontrollerv2 "github.com/fluxcd/helm-controller/api/v2"
 	sourcev1 "github.com/fluxcd/source-controller/api/v1"
-	sourcev1beta2 "github.com/fluxcd/source-controller/api/v1beta2"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	sveltosv1beta1 "github.com/projectsveltos/addon-controller/api/v1beta1"
@@ -100,7 +99,6 @@ var _ = BeforeSuite(func() {
 
 	Expect(kcmv1.AddToScheme(scheme.Scheme)).To(Succeed())
 	Expect(sourcev1.AddToScheme(scheme.Scheme)).To(Succeed())
-	Expect(sourcev1beta2.AddToScheme(scheme.Scheme)).To(Succeed())
 	Expect(helmcontrollerv2.AddToScheme(scheme.Scheme)).To(Succeed())
 	Expect(sveltosv1beta1.AddToScheme(scheme.Scheme)).To(Succeed())
 	Expect(capioperator.AddToScheme(scheme.Scheme)).To(Succeed())

--- a/internal/controller/management_controller.go
+++ b/internal/controller/management_controller.go
@@ -63,14 +63,15 @@ import (
 
 // ManagementReconciler reconciles a Management object
 type ManagementReconciler struct {
-	Client             client.Client
-	Manager            manager.Manager
-	Config             *rest.Config
-	DynamicClient      *dynamic.DynamicClient
-	SystemNamespace    string
-	GlobalRegistry     string
-	GlobalK0sURL       string
-	RegistryCertSecret string
+	Client                 client.Client
+	Manager                manager.Manager
+	Config                 *rest.Config
+	DynamicClient          *dynamic.DynamicClient
+	SystemNamespace        string
+	GlobalRegistry         string
+	GlobalK0sURL           string
+	K0sURLCertSecretName   string // Name of a Secret with K0s Download URL TLS Data; to be passed to the ClusterDeploymentReconciler
+	RegistryCertSecretName string // Name of a Secret with Registry TLS Data; used by ManagementReconciler and ClusterDeploymentReconciler
 
 	defaultRequeueTime time.Duration
 
@@ -117,6 +118,14 @@ func (r *ManagementReconciler) update(ctx context.Context, management *kcm.Manag
 	if updated, err := utils.AddKCMComponentLabel(ctx, r.Client, management); updated || err != nil {
 		if err != nil {
 			l.Error(err, "adding component label")
+		}
+		return ctrl.Result{}, err
+	}
+
+	if changed, err := utils.SetPredeclaredSecretsCondition(ctx, r.Client, management, record.Warnf, r.SystemNamespace, r.RegistryCertSecretName); err != nil { // if changed and NO error we will eventually update the status
+		l.Error(err, "failed to check if given Secrets exist")
+		if changed {
+			return ctrl.Result{}, r.updateStatus(ctx, management)
 		}
 		return ctrl.Result{}, err
 	}
@@ -365,6 +374,8 @@ func (r *ManagementReconciler) startDependentControllers(ctx context.Context, ma
 		IsDisabledValidationWH: r.IsDisabledValidationWH,
 		GlobalRegistry:         r.GlobalRegistry,
 		GlobalK0sURL:           r.GlobalK0sURL,
+		K0sURLCertSecretName:   r.K0sURLCertSecretName,
+		RegistryCertSecretName: r.RegistryCertSecretName,
 	}).SetupWithManager(r.Manager); err != nil {
 		return false, fmt.Errorf("failed to setup controller for ClusterDeployment: %w", err)
 	}
@@ -736,7 +747,7 @@ func (r *ManagementReconciler) getComponentValues(ctx context.Context, name stri
 			capiOperatorValues = map[string]any{"enabled": true}
 		}
 
-		if r.RegistryCertSecret != "" {
+		if r.RegistryCertSecretName != "" {
 			v := make(map[string]any)
 			if currentValues != nil {
 				if raw, ok := currentValues["cluster-api-operator"]; ok {
@@ -747,7 +758,7 @@ func (r *ManagementReconciler) getComponentValues(ctx context.Context, name stri
 				}
 			}
 
-			capiOperatorValues = chartutil.CoalesceTables(capiOperatorValues, processCAPIOperatorCertVolumeMounts(v, r.RegistryCertSecret))
+			capiOperatorValues = chartutil.CoalesceTables(capiOperatorValues, processCAPIOperatorCertVolumeMounts(v, r.RegistryCertSecretName))
 		}
 		componentValues["cluster-api-operator"] = capiOperatorValues
 

--- a/internal/controller/servicetemplate_controller.go
+++ b/internal/controller/servicetemplate_controller.go
@@ -22,7 +22,6 @@ import (
 	"time"
 
 	sourcev1 "github.com/fluxcd/source-controller/api/v1"
-	sourcev1beta2 "github.com/fluxcd/source-controller/api/v1beta2"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	ctrl "sigs.k8s.io/controller-runtime"
@@ -121,7 +120,7 @@ func (r *ServiceTemplateReconciler) reconcileLocalSource(ctx context.Context, te
 			status.ValidationError = err.Error()
 		} else {
 			switch status.SourceStatus.Kind {
-			case sourcev1.GitRepositoryKind, sourcev1.BucketKind, sourcev1beta2.OCIRepositoryKind:
+			case sourcev1.GitRepositoryKind, sourcev1.BucketKind, sourcev1.OCIRepositoryKind:
 				status.Valid = slices.ContainsFunc(status.SourceStatus.Conditions, func(c metav1.Condition) bool {
 					return c.Type == kcm.ReadyCondition && c.Status == metav1.ConditionTrue
 				})
@@ -145,7 +144,7 @@ func (r *ServiceTemplateReconciler) reconcileLocalSource(ctx context.Context, te
 		return fmt.Errorf("failed to get common source status from %s %s: %w", kind, key, err)
 	}
 	switch kind {
-	case sourcev1.GitRepositoryKind, sourcev1.BucketKind, sourcev1beta2.OCIRepositoryKind:
+	case sourcev1.GitRepositoryKind, sourcev1.BucketKind, sourcev1.OCIRepositoryKind:
 		if err = r.sourceStatusFromFluxObject(localSource, status.SourceStatus); err != nil {
 			return fmt.Errorf("failed to get source status from %s %s: %w", kind, key, err)
 		}
@@ -203,7 +202,7 @@ func (r *ServiceTemplateReconciler) SetupWithManager(mgr ctrl.Manager) error {
 			RateLimiter: ratelimit.DefaultFastSlow(),
 		}).
 		For(&kcm.ServiceTemplate{}, builder.WithPredicates(predicate.GenerationChangedPredicate{})).
-		Owns(&sourcev1beta2.OCIRepository{}).
+		Owns(&sourcev1.OCIRepository{}).
 		Owns(&sourcev1.GitRepository{}).
 		Owns(&sourcev1.Bucket{}).
 		Complete(r)
@@ -241,7 +240,7 @@ func (*ServiceTemplateReconciler) sourceStatusFromFluxObject(obj client.Object, 
 		artifact = source.GetArtifact()
 		conditions = make([]metav1.Condition, len(source.Status.Conditions))
 		copy(conditions, source.Status.Conditions)
-	case *sourcev1beta2.OCIRepository:
+	case *sourcev1.OCIRepository:
 		artifact = source.GetArtifact()
 		conditions = make([]metav1.Condition, len(source.Status.Conditions))
 		copy(conditions, source.Status.Conditions)

--- a/internal/controller/servicetemplate_controller_test.go
+++ b/internal/controller/servicetemplate_controller_test.go
@@ -18,7 +18,6 @@ import (
 	"time"
 
 	sourcev1 "github.com/fluxcd/source-controller/api/v1"
-	sourcev1beta2 "github.com/fluxcd/source-controller/api/v1beta2"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	corev1 "k8s.io/api/core/v1"
@@ -38,7 +37,7 @@ var _ = Describe("ServiceTemplate Controller", func() {
 		serviceTemplate kcm.ServiceTemplate
 		gitRepository   sourcev1.GitRepository
 		bucket          sourcev1.Bucket
-		ociRepository   sourcev1beta2.OCIRepository
+		ociRepository   sourcev1.OCIRepository
 	)
 
 	Context("When reconciling ServiceTemplate", func() {
@@ -433,7 +432,7 @@ var _ = Describe("ServiceTemplate Controller", func() {
 						DeploymentType: "Remote",
 						RemoteSourceSpec: &kcm.RemoteSourceSpec{
 							OCI: &kcm.EmbeddedOCIRepositorySpec{
-								OCIRepositorySpec: sourcev1beta2.OCIRepositorySpec{
+								OCIRepositorySpec: sourcev1.OCIRepositorySpec{
 									URL: "oci://ghcr.io/test/test",
 								},
 							},
@@ -450,7 +449,7 @@ var _ = Describe("ServiceTemplate Controller", func() {
 					g.Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(&serviceTemplate), &serviceTemplate)).To(Succeed())
 					g.Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(&serviceTemplate), &ociRepository)).To(Succeed())
 					g.Expect(serviceTemplate.Status.SourceStatus).NotTo(BeNil())
-					g.Expect(serviceTemplate.Status.SourceStatus.Kind).To(Equal(sourcev1beta2.OCIRepositoryKind))
+					g.Expect(serviceTemplate.Status.SourceStatus.Kind).To(Equal(sourcev1.OCIRepositoryKind))
 					g.Expect(serviceTemplate.Status.SourceStatus.Name).To(Equal(serviceTemplate.Name))
 					g.Expect(serviceTemplate.Status.SourceStatus.Namespace).To(Equal(serviceTemplate.Namespace))
 					g.Expect(serviceTemplate.Status.Valid).To(BeFalse())

--- a/internal/controller/suite_test.go
+++ b/internal/controller/suite_test.go
@@ -28,7 +28,6 @@ import (
 
 	helmcontrollerv2 "github.com/fluxcd/helm-controller/api/v2"
 	sourcev1 "github.com/fluxcd/source-controller/api/v1"
-	sourcev1beta2 "github.com/fluxcd/source-controller/api/v1beta2"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	sveltosv1beta1 "github.com/projectsveltos/addon-controller/api/v1beta1"
@@ -124,7 +123,6 @@ var _ = BeforeSuite(func() {
 
 	Expect(kcmv1.AddToScheme(scheme.Scheme)).To(Succeed())
 	Expect(sourcev1.AddToScheme(scheme.Scheme)).To(Succeed())
-	Expect(sourcev1beta2.AddToScheme(scheme.Scheme)).To(Succeed())
 	Expect(helmcontrollerv2.AddToScheme(scheme.Scheme)).To(Succeed())
 	Expect(sveltosv1beta1.AddToScheme(scheme.Scheme)).To(Succeed())
 	Expect(capioperator.AddToScheme(scheme.Scheme)).To(Succeed())

--- a/internal/controller/template_controller.go
+++ b/internal/controller/template_controller.go
@@ -201,7 +201,7 @@ func (r *TemplateReconciler) ReconcileTemplate(ctx context.Context, template tem
 			return ctrl.Result{}, fmt.Errorf("failed to check if Secrets %v exists: %w", helmRepositorySecrets, err)
 		}
 		if !exists {
-			return ctrl.Result{}, r.updateStatus(ctx, template, fmt.Sprintf("Some of the predeclared Secrets (%v) are missing (%v) in the %s namespace", helmRepositorySecrets, missingSecrets, r.SystemNamespace))
+			return ctrl.Result{RequeueAfter: r.defaultRequeueTime}, r.updateStatus(ctx, template, fmt.Sprintf("Some of the predeclared Secrets (%v) are missing (%v) in the %s namespace", helmRepositorySecrets, missingSecrets, r.SystemNamespace))
 		}
 	}
 

--- a/internal/helm/repo.go
+++ b/internal/helm/repo.go
@@ -33,11 +33,11 @@ type DefaultRegistryConfig struct {
 	// objects.  Valid types are 'default' for http/https repositories, and
 	// 'oci' for OCI repositories.  The RepositoryType is set in main based on
 	// the URI scheme of the DefaultRegistryURL.
-	RepoType          string
-	URL               string
-	CredentialsSecret string
-	CertSecret        string
-	Insecure          bool
+	RepoType              string
+	URL                   string
+	CredentialsSecretName string
+	CertSecretName        string
+	Insecure              bool
 }
 
 func (r *DefaultRegistryConfig) HelmRepositorySpec() sourcev1.HelmRepositorySpec {
@@ -47,17 +47,17 @@ func (r *DefaultRegistryConfig) HelmRepositorySpec() sourcev1.HelmRepositorySpec
 		Interval: metav1.Duration{Duration: DefaultReconcileInterval},
 		Insecure: r.Insecure,
 		SecretRef: func() *meta.LocalObjectReference {
-			if r.CredentialsSecret != "" {
+			if r.CredentialsSecretName != "" {
 				return &meta.LocalObjectReference{
-					Name: r.CredentialsSecret,
+					Name: r.CredentialsSecretName,
 				}
 			}
 			return nil
 		}(),
 		CertSecretRef: func() *meta.LocalObjectReference {
-			if r.CertSecret != "" {
+			if r.CertSecretName != "" {
 				return &meta.LocalObjectReference{
-					Name: r.CertSecret,
+					Name: r.CertSecretName,
 				}
 			}
 			return nil

--- a/internal/utils/secrets.go
+++ b/internal/utils/secrets.go
@@ -1,0 +1,149 @@
+// Copyright 2025
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package utils
+
+import (
+	"context"
+	"fmt"
+
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/meta"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	kcmv1 "github.com/K0rdent/kcm/api/v1beta1"
+)
+
+// CheckAllSecretsExistInNamespace returns positive if all of the Secrets with the given names
+// exist in the given namespace.
+// Empty names are ignored.
+func CheckAllSecretsExistInNamespace(ctx context.Context, cl client.Client, namespace string, names ...string) (exist bool, missingSecrets []string, err error) {
+	for _, name := range names {
+		exists, err := checkSecretExistsInNamespace(ctx, namespace, cl, name)
+		if err != nil {
+			return false, nil, fmt.Errorf("failed to fetch Secret: %w", err)
+		}
+		if !exists {
+			missingSecrets = append(missingSecrets, name)
+		}
+	}
+
+	return len(missingSecrets) == 0, missingSecrets, nil
+}
+
+// checkSecretExistsInNamespace checks if a Secret with the given name exists in the given namespace.
+// Empty name is ignored.
+func checkSecretExistsInNamespace(ctx context.Context, namespace string, cl client.Client, name string) (bool, error) {
+	if len(name) == 0 { // sanity check
+		return true, nil
+	}
+	err := cl.Get(ctx, client.ObjectKey{Namespace: namespace, Name: name}, &corev1.Secret{})
+	return err == nil, client.IgnoreNotFound(err)
+}
+
+// ObjectConditionGetter is a common interface over [sigs.k8s.io/controller-runtime/pkg/client.Object]
+// that can get a reference to a slice of [k8s.io/apimachinery/pkg/apis/meta/v1.Condition] to manipulate
+// the object directly.
+type ObjectConditionGetter interface {
+	client.Object
+	GetConditions() *[]metav1.Condition
+}
+
+func getPredeclaredSecretsExistCondition(generation int64, failedMsg string) metav1.Condition {
+	condition := metav1.Condition{
+		Type:               kcmv1.PredeclaredSecretsExistCondition,
+		ObservedGeneration: generation,
+		Status:             metav1.ConditionTrue,
+		Reason:             kcmv1.SucceededReason,
+		Message:            "All predeclared Secrets exist",
+	}
+
+	if failedMsg != "" {
+		condition.Status = metav1.ConditionFalse
+		condition.Reason = kcmv1.FailedReason
+		condition.Message = failedMsg
+	}
+
+	return condition
+}
+
+// SetPredeclaredSecretsCondition checks if all Secret objects with the given names in the given namespace exist.
+// If one of the Secret objects does not exist, creates a new warning Event and returns error.
+// In either case, sets the [github.com/K0rdent/kcm/api/v1beta1.PredeclaredSecretsExistCondition] condition with corresponding status.
+//
+// Does nothing if all of the given names are empty.
+func SetPredeclaredSecretsCondition(ctx context.Context, cl client.Client, base ObjectConditionGetter, eventFn func(runtime.Object, int64, string, string, ...any), namespace string, names ...string) (changed bool, err error) {
+	if len(names) == 0 {
+		return false, nil
+	}
+
+	fastReturn := true
+	for _, v := range names {
+		if v != "" {
+			fastReturn = false
+			break
+		}
+	}
+	if fastReturn {
+		return false, nil
+	}
+
+	exist, missingSecrets, err := CheckAllSecretsExistInNamespace(ctx, cl, namespace, names...)
+	if err != nil {
+		return false, fmt.Errorf("failed to check if Secrets %v exists: %w", names, err)
+	}
+
+	ldebug := ctrl.LoggerFrom(ctx).V(1).WithName("secrets-checker").WithValues("given_secrets", names, "given_namespace", namespace)
+	if exist {
+		ldebug.Info("All Secrets exist")
+		return meta.SetStatusCondition(base.GetConditions(), getPredeclaredSecretsExistCondition(base.GetGeneration(), "")), nil
+	}
+
+	ldebug.Info("Some required Secrets are missing")
+
+	missingMsg := fmt.Sprintf("Some of the predeclared Secrets (%v) are missing (%v) in the %s namespace", names, missingSecrets, namespace)
+
+	if changed = meta.SetStatusCondition(base.GetConditions(), getPredeclaredSecretsExistCondition(base.GetGeneration(), missingMsg)); changed {
+		eventFn(base, base.GetGeneration(), "MissingDeclaredSecrets", missingMsg)
+	}
+
+	return changed, fmt.Errorf("missing secret names: %v", missingSecrets)
+}
+
+// CopySecret copies a Secret with the given key to the given namespace.
+func CopySecret(ctx context.Context, cl client.Client, key client.ObjectKey, toNamespace string) error {
+	if key.Name == "" || key.Namespace == toNamespace { // sanity check
+		return nil
+	}
+
+	secret := new(corev1.Secret)
+	if err := cl.Get(ctx, key, secret); err != nil {
+		return fmt.Errorf("failed to get Secret %s: %w", key, err)
+	}
+
+	newSecret := secret.DeepCopy()
+	newSecret.ObjectMeta = metav1.ObjectMeta{
+		Name:      key.Name,
+		Namespace: toNamespace,
+	}
+
+	if err := cl.Create(ctx, newSecret); client.IgnoreAlreadyExists(err) != nil {
+		return fmt.Errorf("failed to create Secret %s/%s: %w", newSecret.Namespace, newSecret.Name, err)
+	}
+
+	return nil
+}

--- a/internal/utils/secrets.go
+++ b/internal/utils/secrets.go
@@ -136,10 +136,15 @@ func CopySecret(ctx context.Context, cl client.Client, key client.ObjectKey, toN
 	}
 
 	newSecret := secret.DeepCopy()
-	newSecret.ObjectMeta = metav1.ObjectMeta{
-		Name:      key.Name,
-		Namespace: toNamespace,
-	}
+	newSecret.SetCreationTimestamp(metav1.Time{})
+	newSecret.SetFinalizers(nil)
+	newSecret.SetManagedFields(nil)
+	newSecret.SetOwnerReferences(nil)
+	newSecret.SetResourceVersion("")
+	newSecret.SetSelfLink("")
+	newSecret.SetUID("")
+
+	newSecret.SetNamespace(toNamespace)
 
 	if err := cl.Create(ctx, newSecret); client.IgnoreAlreadyExists(err) != nil {
 		return fmt.Errorf("failed to create Secret %s/%s: %w", newSecret.Namespace, newSecret.Name, err)

--- a/templates/provider/kcm/templates/crds/k0rdent.mirantis.com_clusterdeployments.yaml
+++ b/templates/provider/kcm/templates/crds/k0rdent.mirantis.com_clusterdeployments.yaml
@@ -1108,6 +1108,9 @@ spec:
                   - type
                   type: object
                 type: array
+                x-kubernetes-list-map-keys:
+                - type
+                x-kubernetes-list-type: map
               k8sVersion:
                 description: |-
                   Currently compatible exact Kubernetes version of the cluster. Being set only if
@@ -1188,6 +1191,9 @@ spec:
                         - type
                         type: object
                       type: array
+                      x-kubernetes-list-map-keys:
+                      - type
+                      x-kubernetes-list-type: map
                   required:
                   - clusterName
                   type: object

--- a/templates/provider/kcm/templates/crds/k0rdent.mirantis.com_clustertemplates.yaml
+++ b/templates/provider/kcm/templates/crds/k0rdent.mirantis.com_clustertemplates.yaml
@@ -1121,7 +1121,7 @@ spec:
                             description: |-
                               Namespace is the namespace of the local source. Cross-namespace references
                               are only allowed when the Kind is one of [github.com/fluxcd/source-controller/api/v1.GitRepository],
-                              [github.com/fluxcd/source-controller/api/v1.Bucket] or [github.com/fluxcd/source-controller/api/v1beta2.OCIRepository].
+                              [github.com/fluxcd/source-controller/api/v1.Bucket] or [github.com/fluxcd/source-controller/api/v1.OCIRepository].
                               If the Kind is ConfigMap or Secret, the namespace will be ignored.
                             type: string
                         required:
@@ -1525,9 +1525,6 @@ spec:
                                   authenticating with a certificate; the CA cert is useful if
                                   you are using a self-signed server certificate. The Secret must
                                   be of type `Opaque` or `kubernetes.io/tls`.
-
-                                  Note: Support for the `caFile`, `certFile` and `keyFile` keys have
-                                  been deprecated.
                                 properties:
                                   name:
                                     description: Name of the referent.

--- a/templates/provider/kcm/templates/crds/k0rdent.mirantis.com_credentials.yaml
+++ b/templates/provider/kcm/templates/crds/k0rdent.mirantis.com_credentials.yaml
@@ -312,6 +312,9 @@ spec:
                   - type
                   type: object
                 type: array
+                x-kubernetes-list-map-keys:
+                - type
+                x-kubernetes-list-type: map
               ready:
                 default: false
                 description: Ready holds the readiness of Credentials.

--- a/templates/provider/kcm/templates/crds/k0rdent.mirantis.com_managements.yaml
+++ b/templates/provider/kcm/templates/crds/k0rdent.mirantis.com_managements.yaml
@@ -479,7 +479,6 @@ spec:
                   - status
                   - type
                   type: object
-                maxItems: 32
                 type: array
                 x-kubernetes-list-map-keys:
                 - type

--- a/templates/provider/kcm/templates/crds/k0rdent.mirantis.com_multiclusterservices.yaml
+++ b/templates/provider/kcm/templates/crds/k0rdent.mirantis.com_multiclusterservices.yaml
@@ -1024,6 +1024,9 @@ spec:
                   - type
                   type: object
                 type: array
+                x-kubernetes-list-map-keys:
+                - type
+                x-kubernetes-list-type: map
               observedGeneration:
                 description: ObservedGeneration is the last observed generation.
                 format: int64
@@ -1099,6 +1102,9 @@ spec:
                         - type
                         type: object
                       type: array
+                      x-kubernetes-list-map-keys:
+                      - type
+                      x-kubernetes-list-type: map
                   required:
                   - clusterName
                   type: object

--- a/templates/provider/kcm/templates/crds/k0rdent.mirantis.com_providertemplates.yaml
+++ b/templates/provider/kcm/templates/crds/k0rdent.mirantis.com_providertemplates.yaml
@@ -1122,7 +1122,7 @@ spec:
                             description: |-
                               Namespace is the namespace of the local source. Cross-namespace references
                               are only allowed when the Kind is one of [github.com/fluxcd/source-controller/api/v1.GitRepository],
-                              [github.com/fluxcd/source-controller/api/v1.Bucket] or [github.com/fluxcd/source-controller/api/v1beta2.OCIRepository].
+                              [github.com/fluxcd/source-controller/api/v1.Bucket] or [github.com/fluxcd/source-controller/api/v1.OCIRepository].
                               If the Kind is ConfigMap or Secret, the namespace will be ignored.
                             type: string
                         required:
@@ -1526,9 +1526,6 @@ spec:
                                   authenticating with a certificate; the CA cert is useful if
                                   you are using a self-signed server certificate. The Secret must
                                   be of type `Opaque` or `kubernetes.io/tls`.
-
-                                  Note: Support for the `caFile`, `certFile` and `keyFile` keys have
-                                  been deprecated.
                                 properties:
                                   name:
                                     description: Name of the referent.

--- a/templates/provider/kcm/templates/crds/k0rdent.mirantis.com_releases.yaml
+++ b/templates/provider/kcm/templates/crds/k0rdent.mirantis.com_releases.yaml
@@ -290,6 +290,9 @@ spec:
                   - type
                   type: object
                 type: array
+                x-kubernetes-list-map-keys:
+                - type
+                x-kubernetes-list-type: map
               observedGeneration:
                 description: ObservedGeneration is the last observed generation.
                 format: int64

--- a/templates/provider/kcm/templates/crds/k0rdent.mirantis.com_servicetemplates.yaml
+++ b/templates/provider/kcm/templates/crds/k0rdent.mirantis.com_servicetemplates.yaml
@@ -2523,7 +2523,7 @@ spec:
                             description: |-
                               Namespace is the namespace of the local source. Cross-namespace references
                               are only allowed when the Kind is one of [github.com/fluxcd/source-controller/api/v1.GitRepository],
-                              [github.com/fluxcd/source-controller/api/v1.Bucket] or [github.com/fluxcd/source-controller/api/v1beta2.OCIRepository].
+                              [github.com/fluxcd/source-controller/api/v1.Bucket] or [github.com/fluxcd/source-controller/api/v1.OCIRepository].
                               If the Kind is ConfigMap or Secret, the namespace will be ignored.
                             type: string
                         required:
@@ -2927,9 +2927,6 @@ spec:
                                   authenticating with a certificate; the CA cert is useful if
                                   you are using a self-signed server certificate. The Secret must
                                   be of type `Opaque` or `kubernetes.io/tls`.
-
-                                  Note: Support for the `caFile`, `certFile` and `keyFile` keys have
-                                  been deprecated.
                                 properties:
                                   name:
                                     description: Name of the referent.
@@ -3336,7 +3333,7 @@ spec:
                         description: |-
                           Namespace is the namespace of the local source. Cross-namespace references
                           are only allowed when the Kind is one of [github.com/fluxcd/source-controller/api/v1.GitRepository],
-                          [github.com/fluxcd/source-controller/api/v1.Bucket] or [github.com/fluxcd/source-controller/api/v1beta2.OCIRepository].
+                          [github.com/fluxcd/source-controller/api/v1.Bucket] or [github.com/fluxcd/source-controller/api/v1.OCIRepository].
                           If the Kind is ConfigMap or Secret, the namespace will be ignored.
                         type: string
                     required:
@@ -3739,9 +3736,6 @@ spec:
                               authenticating with a certificate; the CA cert is useful if
                               you are using a self-signed server certificate. The Secret must
                               be of type `Opaque` or `kubernetes.io/tls`.
-
-                              Note: Support for the `caFile`, `certFile` and `keyFile` keys have
-                              been deprecated.
                             properties:
                               name:
                                 description: Name of the referent.
@@ -3985,7 +3979,7 @@ spec:
                         description: |-
                           Namespace is the namespace of the local source. Cross-namespace references
                           are only allowed when the Kind is one of [github.com/fluxcd/source-controller/api/v1.GitRepository],
-                          [github.com/fluxcd/source-controller/api/v1.Bucket] or [github.com/fluxcd/source-controller/api/v1beta2.OCIRepository].
+                          [github.com/fluxcd/source-controller/api/v1.Bucket] or [github.com/fluxcd/source-controller/api/v1.OCIRepository].
                           If the Kind is ConfigMap or Secret, the namespace will be ignored.
                         type: string
                     required:
@@ -4388,9 +4382,6 @@ spec:
                               authenticating with a certificate; the CA cert is useful if
                               you are using a self-signed server certificate. The Secret must
                               be of type `Opaque` or `kubernetes.io/tls`.
-
-                              Note: Support for the `caFile`, `certFile` and `keyFile` keys have
-                              been deprecated.
                             properties:
                               name:
                                 description: Name of the referent.

--- a/templates/provider/kcm/templates/crds/k0rdent.mirantis.com_servicetemplates.yaml
+++ b/templates/provider/kcm/templates/crds/k0rdent.mirantis.com_servicetemplates.yaml
@@ -4774,6 +4774,9 @@ spec:
                       - type
                       type: object
                     type: array
+                    x-kubernetes-list-map-keys:
+                    - type
+                    x-kubernetes-list-type: map
                   kind:
                     description: Kind is the kind of the remote source.
                     type: string

--- a/templates/provider/kcm/templates/deployment.yaml
+++ b/templates/provider/kcm/templates/deployment.yaml
@@ -28,8 +28,11 @@ spec:
         {{- if .Values.controller.registryCredsSecret }}
         - --registry-creds-secret={{ .Values.controller.registryCredsSecret }}
         {{- end }}
+        {{- if .Values.controller.k0sURLCertSecret }}
+        - --k0s-url-cert-secret-name={{ .Values.controller.k0sURLCertSecret }}
+        {{- end }}
         {{- if .Values.controller.registryCertSecret }}
-        - --registry-cert-secret={{ .Values.controller.registryCertSecret }}
+        - --registry-cert-secret-name={{ .Values.controller.registryCertSecret }}
         {{- end }}
         - --create-management={{ .Values.controller.createManagement }}
         - --create-access-management={{ .Values.controller.createAccessManagement }}

--- a/templates/provider/kcm/templates/rbac/controller/roles.yaml
+++ b/templates/provider/kcm/templates/rbac/controller/roles.yaml
@@ -260,6 +260,7 @@ rules:
   - list
   - watch
   - update
+  - create # copy secrets between namespaces
 - apiGroups:
   - ""
   resources:

--- a/templates/provider/kcm/values.schema.json
+++ b/templates/provider/kcm/values.schema.json
@@ -143,6 +143,12 @@
         "insecureRegistry": {
           "type": "boolean"
         },
+        "k0sURLCertSecret": {
+          "description": "Name of a Secret containing K0s Download URL TLS Data",
+          "type": [
+            "string"
+          ]
+        },
         "logger": {
           "description": "Global controllers logger settings",
           "properties": {
@@ -212,10 +218,16 @@
           ]
         },
         "registryCertSecret": {
-          "type": "string"
+          "description": "Name of a Secret containing Registry TLS Data",
+          "type": [
+            "string"
+          ]
         },
         "registryCredsSecret": {
-          "type": "string"
+          "description": "Name of a Secret containing Registry Credentials (Auth) Data",
+          "type": [
+            "string"
+          ]
         },
         "templatesRepoURL": {
           "type": "string"

--- a/templates/provider/kcm/values.yaml
+++ b/templates/provider/kcm/values.yaml
@@ -14,8 +14,9 @@ controller:
   templatesRepoURL: "oci://ghcr.io/k0rdent/kcm/charts"
   globalRegistry: ""
   globalK0sURL: ""
-  registryCredsSecret: ""
-  registryCertSecret: ""
+  k0sURLCertSecret: "" # @schema type: string; description: Name of a Secret containing K0s Download URL TLS Data
+  registryCredsSecret: "" # @schema type: string; description: Name of a Secret containing Registry Credentials (Auth) Data
+  registryCertSecret: "" # @schema type: string; description: Name of a Secret containing Registry TLS Data
   insecureRegistry: false
   createManagement: true
   createAccessManagement: true


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Documentation**
  - Updated references in documentation and schema descriptions to use the latest supported OCIRepository API version.
  - Removed outdated deprecation notes regarding secret key support in CRD descriptions.
  - Added descriptive comments for new and existing secret-related configuration fields.

- **New Features**
  - Added support for managing K0s Download URL TLS secret alongside existing registry secrets.
  - Introduced condition to indicate existence of required predeclared secrets.
  - Enabled automatic copying of required secrets across namespaces during reconciliation.

- **Refactor**
  - Replaced all usage of the deprecated OCIRepository API version with the current version throughout the application and tests.
  - Renamed secret-related configuration fields for clarity and consistency.
  - Improved condition handling by adding patch and merge strategy annotations for conditions fields.

- **Bug Fixes**
  - Enhanced reconciliation logic to verify presence of required secrets before proceeding.
  - Adjusted event reporting to emit warnings only when condition changes occur.
  - Fixed secret copying and reconciliation flow to ensure required secrets are available in target namespaces.

- **Chores**
  - Cleaned up unused imports and updated references to ensure compatibility with the latest API version.
  - Added RBAC permission to allow creation of secrets for cross-namespace copying.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->